### PR TITLE
Update wod-item-base.js Fix: Art Powers not rollable by default

### DIFF
--- a/module/items/data/wod-item-base.js
+++ b/module/items/data/wod-item-base.js
@@ -34,6 +34,14 @@ export class WoDItem extends Item {
 
         try {
             let data = foundry.utils.duplicate(this);
+			// Fix for Art Powers (Changeling) not being rollable by default		
+		if (
+		  this.type === "Power" &&
+		  this.system?.type === "wod.types.artpower"
+		) {
+		  data.system.isrollable = true;
+		  data.system.difficulty ??= "";
+		}
 
             const imgUrl = _getImage(data);
 


### PR DESCRIPTION
Fixes an issue where newly created Changeling Art Power items are not flagged as rollable (system.isrollable = true). This prevented the expected roll behavior from appearing in the UI. Fix applied in wod-item-base.js during _onCreate.

Addresses issue #1213